### PR TITLE
Mention CC0 in README and documentation index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,5 @@ Source code repository (and issue tracker):
     https://github.com/mgeier/jupyter-format/
 
 License:
-    MIT -- see the file ``LICENSE`` for details.
+    Dedicated to the public domain using CC0 --
+    see the file ``LICENSE`` for details.

--- a/doc/index.jupyter
+++ b/doc/index.jupyter
@@ -13,7 +13,8 @@ markdown
     Source code repository and issue tracker:
     https://github.com/mgeier/jupyter-format/
     
-    License: MIT -- see the file ``LICENSE`` for details.
+    Dedicated to the public domain using CC0 --
+    see the file ``LICENSE`` for details.
     
     <div class="alert alert-info">
     


### PR DESCRIPTION
This has been forgotten in eb481fb6344e6fbc443198d14658f1568722d828.